### PR TITLE
Wait for 'hello' message before writing into the stream

### DIFF
--- a/src/slackstream.h
+++ b/src/slackstream.h
@@ -38,6 +38,7 @@ private:
     QPointer<QTimer> checkTimer;
 
     bool isConnected;
+    bool helloReceived;
     QAtomicInteger<int> lastMessageId;
 };
 


### PR DESCRIPTION
Slack does not seem to like when we send it a message before it could
send us 'hello' and disconnects the socket immediatelly.

This fixes the app constantly trying to reconnect to the websocket,
making it usable again.